### PR TITLE
New Shutdown Modes

### DIFF
--- a/ROSCO/rosco_registry/rosco_types.yaml
+++ b/ROSCO/rosco_registry/rosco_types.yaml
@@ -364,14 +364,20 @@ ControlParameters:
     # Shutdown 
     SD_Mode:
       <<: *integer
-      description: Shutdown mode {0 - no shutdown procedure, 1 - pitch to max pitch at shutdown}
+      description: Shutdown mode {0 - no shutdown procedure, 1 - pitch to max pitch at shutdown, 2- Yaw cutout, 3- Max. blade pitch misaligment, 4- 1 and 2, 5- 1 and 3, 6- 2 and 3, 7- all}
     SD_MaxPit:
       <<: *real
       description: Maximum blade pitch angle to initiate shutdown, [rad]
     SD_CornerFreq:
       <<: *real
       description: Cutoff Frequency for first order low-pass filter for blade pitch angle, [rad/s]
-    
+    SD_MaxYaw_Cutout:        # by Fekry   
+      <<: *real
+      description: Maximum Yaw cutout to initiate shutdown [rad], {default = 30 deg.}
+    SD_MaxBlade_Ptch_Misalign: # by Fekry
+      <<: *real          
+      description: Maximum blade pitch misaligment angle to initiate shutdown [rad], {default = 3 deg.}
+
     # Floating
     Fl_Mode:
       <<: *integer
@@ -863,6 +869,9 @@ LocalVariables:
     HorWindV: 
       <<: *real 
       description: Hub height wind speed m/s
+    YawErr: #! by Fekry
+      <<: *real 
+      description: (Wind Direction - Yaw Angle) radians
     rootMOOP: 
       <<: *real
       description: Blade root bending moment [Nm]
@@ -874,6 +883,10 @@ LocalVariables:
     BlPitch: 
       <<: *real
       description: Blade pitch [rad]
+      size: 3
+    BlPitch_OpenfAST: #by Fekry
+      <<: *real
+      description: Blade pitch imported from OpenFAST[rad]
       size: 3
     BlPitchCMeas: 
       <<: *real

--- a/ROSCO/src/Controllers.f90
+++ b/ROSCO/src/Controllers.f90
@@ -90,7 +90,7 @@ CONTAINS
         ENDIF
         
         ! Shutdown
-        IF (CntrPar%SD_Mode == 1) THEN
+        IF (CntrPar%SD_Mode > 0) THEN !by Fekry
             LocalVar%PC_PitComT = Shutdown(LocalVar, CntrPar, objInst)
         ENDIF
         

--- a/ROSCO/src/ReadSetParameters.f90
+++ b/ROSCO/src/ReadSetParameters.f90
@@ -45,6 +45,7 @@ CONTAINS
         LocalVar%RotSpeed           = avrSWAP(21)
         LocalVar%GenTqMeas          = avrSWAP(23)
         LocalVar%NacVane            = avrSWAP(24) * R2D
+        LocalVar%YawErr             = avrSWAP(24)    ! by Fekry (same as NacVane)
         LocalVar%HorWindV           = avrSWAP(27)
         LocalVar%rootMOOP(1)        = avrSWAP(30)
         LocalVar%rootMOOP(2)        = avrSWAP(31)
@@ -101,6 +102,10 @@ CONTAINS
             END IF
 
         ENDIF
+        
+        LocalVar%BlPitch_OpenfAST(1) = avrSWAP(4)     ! by Fekry
+        LocalVar%BlPitch_OpenfAST(2) = avrSWAP(33)    ! by Fekry
+        LocalVar%BlPitch_OpenfAST(3) = avrSWAP(34)    ! by Fekry
 
         LocalVar%BlPitchCMeas = (1 / REAL(LocalVar%NumBl)) * (LocalVar%BlPitch(1) + LocalVar%BlPitch(2) + LocalVar%BlPitch(3)) 
 
@@ -523,6 +528,8 @@ CONTAINS
         !------------ SHUTDOWN ------------
         CALL ParseInput(FileLines,  'SD_MaxPit',        CntrPar%SD_MaxPit,      accINFILE(1),   ErrVar, CntrPar%SD_Mode == 0, UnEc)
         CALL ParseInput(FileLines,  'SD_CornerFreq',    CntrPar%SD_CornerFreq,  accINFILE(1),   ErrVar, CntrPar%SD_Mode == 0, UnEc)
+        CALL ParseInput(FileLines,  'SD_MaxYaw_Cutout',    CntrPar%SD_MaxYaw_Cutout,  accINFILE(1),   ErrVar, CntrPar%SD_Mode == 0, UnEc) !by Fekry
+        CALL ParseInput(FileLines,  'SD_MaxBlade_Ptch_Misalign',    CntrPar%SD_MaxBlade_Ptch_Misalign,  accINFILE(1),   ErrVar, CntrPar%SD_Mode == 0, UnEc) !by Fekry
         IF (ErrVar%aviFAIL < 0) RETURN
 
         !------------ FLOATING ------------
@@ -792,9 +799,9 @@ CONTAINS
         ENDIF
 
         ! SD_Mode
-        IF ((CntrPar%SD_Mode < 0) .OR. (CntrPar%SD_Mode > 1)) THEN
+        IF ((CntrPar%SD_Mode < 0) .OR. (CntrPar%SD_Mode > 7)) THEN !by Fekry
             ErrVar%aviFAIL = -1
-            ErrVar%ErrMsg  = 'SD_Mode must be 0 or 1.'
+            ErrVar%ErrMsg  = 'SD_Mode must be integer between 0 and 7.'
         ENDIF
 
         ! Fl_Mode

--- a/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/controller.py
@@ -87,6 +87,8 @@ class Controller():
         self.ss_pcgain          = controller_params['ss_pcgain']
         self.ps_percent         = controller_params['ps_percent']
         self.sd_maxpit          = controller_params['sd_maxpit']
+        self.sd_maxyaw_cutout          = controller_params['sd_maxyaw_cutout'] #by Fekry
+        self.sd_maxblade_ptch_misalign          = controller_params['sd_maxblade_ptch_misalign'] #by Fekry
         self.WS_GS_n            = controller_params['WS_GS_n']
         self.PC_GS_n            = controller_params['PC_GS_n']
         self.flp_maxpit         = controller_params['flp_maxpit']
@@ -335,6 +337,18 @@ class Controller():
             self.sd_maxpit = self.sd_maxpit
         else:
             self.sd_maxpit = pitch_op[-1]
+            
+        # max Yaw cutout for shutdown  #by Fekry
+        if self.sd_maxyaw_cutout:
+            self.sd_maxyaw_cutout = self.sd_maxyaw_cutout
+        else:
+            self.sd_maxyaw_cutout = pitch_op[-1]    
+            
+        # max blade pitch misalignment for shutdown  #by Fekry
+        if self.sd_maxblade_ptch_misalign:
+            self.sd_maxblade_ptch_misalign = self.sd_maxblade_ptch_misalign
+        else:
+            self.sd_maxblade_ptch_misalign = pitch_op[-1] 
 
         # Set IPC ramp inputs if not already defined
         if max(self.IPC_Vramp) == 0.0:

--- a/ROSCO_toolbox/inputs/toolbox_schema.yaml
+++ b/ROSCO_toolbox/inputs/toolbox_schema.yaml
@@ -158,9 +158,9 @@ properties:
             SD_Mode:            
                 type: number
                 minimum: 0
-                maximum: 1
+                maximum: 7 #by Fekry
                 default: 0
-                description: Shutdown mode (0- no shutdown procedure, 1- pitch to max pitch at shutdown)
+                description: Shutdown mode (0- no shutdown procedure, 1- pitch to max pitch at shutdown, 2- Yaw cutout, 3- Max. blade pitch misaligment, 4- 1 and 2, 5- 1 and 3, 6- 2 and 3, 7- all )
             TD_Mode:            
                 type: number
                 minimum: 0
@@ -305,6 +305,16 @@ properties:
                 type: number
                 default: 0.6981
                 unit: rad
+            sd_maxyaw_cutout:        #by Fekry   
+                description: Maximum Yaw cutout to initiate shutdown [rad], {default = 30 deg.}
+                type: number
+                default: 0.5236
+                unit: rad   
+            sd_maxblade_ptch_misalign:       #by Fekry    
+                description: Maximum blade pitch misaligment angle to initiate shutdown [rad], {default = 3 deg.}
+                type: number
+                default: 0.05236
+                unit: rad 
             flp_maxpit:            
                 description: Maximum (and minimum) flap pitch angle [rad]
                 type: number

--- a/ROSCO_toolbox/utilities.py
+++ b/ROSCO_toolbox/utilities.py
@@ -206,7 +206,9 @@ def write_DISCON(turbine, controller, param_file='DISCON.IN', txt_filename='Cp_C
     file.write('\n')
     file.write('!------- SHUTDOWN -----------------------------------------------------------\n')
     file.write('{:<014.5f}      ! SD_MaxPit         - Maximum blade pitch angle to initiate shutdown, [rad]\n'.format(rosco_vt['SD_MaxPit']))
-    file.write('{:<014.5f}      ! SD_CornerFreq     - Cutoff Frequency for first order low-pass filter for blade pitch angle, [rad/s]\n'.format(rosco_vt['SD_CornerFreq']))
+    file.write('{:<014.5f}      ! SD_CornerFreq     - Cutoff Frequency for first order low-pass filter for blade pitch angle, [rad/s]\n'.format(rosco_vt['SD_CornerFreq'])) 
+    file.write('{:<014.5f}      ! SD_MaxYaw_Cutout         - Maximum Yaw cutout to initiate shutdown, [rad]\n'.format(rosco_vt['SD_MaxYaw_Cutout']))  #by Fekry
+    file.write('{:<014.5f}      ! SD_MaxBlade_Ptch_Misalign         - Maximum blade pitch misaligment angle to initiate shutdown, [rad]\n'.format(rosco_vt['SD_MaxBlade_Ptch_Misalign'])) #by Fekry
     file.write('\n')
     file.write('!------- Floating -----------------------------------------------------------\n')
     if rosco_vt['Fl_Mode'] == 2:
@@ -552,6 +554,8 @@ def DISCON_dict(turbine, controller, txt_filename=None):
     # ------- SHUTDOWN -------
     DISCON_dict['SD_MaxPit']        = controller.sd_maxpit
     DISCON_dict['SD_CornerFreq']    = controller.f_sd_cornerfreq
+    DISCON_dict['SD_MaxYaw_Cutout']    = controller.sd_maxyaw_cutout #by Fekry
+    DISCON_dict['SD_MaxBlade_Ptch_Misalign']    = controller.sd_maxblade_ptch_misalign #by Fekry
     # ------- Floating -------
     DISCON_dict['Fl_Kp']            = controller.Kp_float
     # ------- FLAP ACTUATION -------


### PR DESCRIPTION
## Description and Purpose
I added a new variable that  is required for the application of different shutdown modes.

## Type of change
- Add new variable to rosco_types.yaml:SD_MaxYaw_Cutout, SD_MaxBlade_Ptch_Misalign, YawErr, and BlPitch_OpenfAST
- The following modifications have been made in ReadSetParameters.f90:
  1- Connect YawErr and Blpitch_OpenfAST to avrSWAP in ReadAvrSWAP SUBROUTINE.
  2- Add SD_MaxYaw_Cutout and SD_MaxBlade_Ptch_Misalign calls of ParseInput in ReadControlParameterFileSub SUBROUTINE (SHUTDOWN section).
  3- Change the range of values of SD_Mode conditions in CheckInputs SUBROUTINE.
- Modify the Shutdown FUNCTION of the ControllerBlocks.f90 to meet the new SD_Mode.
- Modify and add variables in toolbox_schema.yaml: SD_Mode, sd_maxyaw_cutout, and sd_maxblade_ptch_misalign.
- In utilities.py file inside ROSCO_toolbox folder, four lines have been added to write the new variables in DIScon.in file and assign the new variables in the DISCON_dict. Those lines are for SD_MaxYaw_Cutout and SD_MaxBlade_Ptch_Misalign
- The controller class of controller.py in ROSCO_toolbox folder is modified to consider the new variables.
- In controllers.f90, the  SUBROUTINE of PitchControl, Modify the activation condition of SD_mode to be > 0
